### PR TITLE
Fix skin button prefab visibility

### DIFF
--- a/Assets/Resources/Prefabs/SkinButton.prefab
+++ b/Assets/Resources/Prefabs/SkinButton.prefab
@@ -19,7 +19,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &5386857762134896778
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- ensure `SkinButton` prefab is active when instantiated so shop list appears

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6884e7f3ff6c832cb9be1a00dc991257